### PR TITLE
4 feature createorder-order save and companyClient

### DIFF
--- a/src/main/java/com/fhsh/daitda/order/application/client/CompanyClient.java
+++ b/src/main/java/com/fhsh/daitda/order/application/client/CompanyClient.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.order.application.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface CompanyClient {
+	Map<UUID, String> getProductNames(UUID supplierCompanyId, List<UUID> productIds);
+}

--- a/src/main/java/com/fhsh/daitda/order/application/command/OrderCreateCommand.java
+++ b/src/main/java/com/fhsh/daitda/order/application/command/OrderCreateCommand.java
@@ -1,0 +1,15 @@
+package com.fhsh.daitda.order.application.command;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+
+public record OrderCreateCommand (
+	UUID supplierCompanyId,
+	UUID receiverCompanyId,
+	LocalDateTime deadlineAt,
+	String requestMessage,
+	List<OrderItemCommand> orderItems
+) {
+}

--- a/src/main/java/com/fhsh/daitda/order/application/command/OrderItemCommand.java
+++ b/src/main/java/com/fhsh/daitda/order/application/command/OrderItemCommand.java
@@ -1,0 +1,11 @@
+package com.fhsh.daitda.order.application.command;
+
+import java.util.List;
+import java.util.UUID;
+
+
+public record OrderItemCommand(
+	UUID productId,
+	int quantity
+) {
+}

--- a/src/main/java/com/fhsh/daitda/order/application/result/OrderCreateResult.java
+++ b/src/main/java/com/fhsh/daitda/order/application/result/OrderCreateResult.java
@@ -1,0 +1,15 @@
+package com.fhsh.daitda.order.application.result;
+
+import java.util.UUID;
+
+import com.fhsh.daitda.order.domain.entity.Order;
+
+public record OrderCreateResult(
+	UUID orderId
+) {
+	public static OrderCreateResult from(Order order) {
+		return new OrderCreateResult(
+			order.getOrderId()
+		);
+	}
+}

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandService.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.order.application.service.command;
+
+import com.fhsh.daitda.order.application.command.OrderCreateCommand;
+import com.fhsh.daitda.order.application.result.OrderCreateResult;
+
+public interface OrderCommandService {
+	OrderCreateResult createOrder(OrderCreateCommand orderCreateCommand);
+}

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -26,13 +26,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 		List<UUID> productIds = orderCreateCommand.orderItems().stream()
 			.map(OrderItemCommand::productId)
 			.toList();
-		List<OrderItemInfo> itemInfos = createOrderItemInfo(orderCreateCommand.orderItems(), productIds);
+		List<OrderItemInfo> itemInfos = createOrderItemInfo(orderCreateCommand.orderItems(), productIds, orderCreateCommand.supplierCompanyId());
 
 		Order order = Order.create(itemInfos);
 
 		return OrderCreateResult.from(order);
 	}
-	private List<OrderItemInfo> createOrderItemInfo(List<OrderItemCommand> orderItemCommands, List<UUID> productIds) {
+	private List<OrderItemInfo> createOrderItemInfo(List<OrderItemCommand> orderItemCommands, List<UUID> productIds, UUID supplierCompanyId) {
 		Map<UUID, String> productNames = companyClient.getProductNames(supplierCompanyId, productIds);
 
 		return orderItemCommands.stream().map(

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package com.fhsh.daitda.order.application.service.command;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.fhsh.daitda.order.application.client.CompanyClient;
+import com.fhsh.daitda.order.application.command.OrderCreateCommand;
+import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.application.result.OrderCreateResult;
+import com.fhsh.daitda.order.domain.entity.Order;
+import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class OrderCommandServiceImpl implements OrderCommandService {
+	@Autowired
+	private final CompanyClient companyClient;
+
+	public OrderCreateResult createOrder(OrderCreateCommand orderCreateCommand) {
+		List<UUID> productIds = orderCreateCommand.orderItems().stream()
+			.map(OrderItemCommand::productId)
+			.toList();
+		List<OrderItemInfo> itemInfos = createOrderItemInfo(orderCreateCommand.orderItems(), productIds);
+
+		Order order = Order.create(itemInfos);
+
+		return OrderCreateResult.from(order);
+	}
+	private List<OrderItemInfo> createOrderItemInfo(List<OrderItemCommand> orderItemCommands, List<UUID> productIds) {
+		Map<UUID, String> productNames = companyClient.getProductNames(supplierCompanyId, productIds);
+
+		return orderItemCommands.stream().map(
+			itemCommand -> {
+				String productName = productNames.get(itemCommand.productId());
+				return new OrderItemInfo(itemCommand.productId(), productName, itemCommand.quantity());
+			}
+		).toList();
+	}
+}

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
@@ -5,10 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
 import com.fhsh.daitda.order.domain.enums.OrderStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -37,10 +38,10 @@ public class Order {
 	@OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<OrderItem> orderItems = new ArrayList<>();
 
-	private LocalDateTime deadlineAt;
 	@Enumerated(EnumType.STRING)
 	private OrderStatus orderStatus;
-	private String requestMessage;
+	@Embedded
+	private OrderRequest orderRequest;
 
 	public void addOrderItem(OrderItem item) {
 		orderItems.add(item);
@@ -48,12 +49,12 @@ public class Order {
 	}
 
 	// Order 와 OrderItem 저장 확인 위해 간단히, 추후 수정 예정
-	public static Order create(List<OrderItemCommand> itemInfos) {
+	public static Order create(List<OrderItemInfo> itemInfos) {
 		Order order = new Order();
 
 		order.orderStatus = OrderStatus.CREATED;
 
-		for (OrderItemCommand info : itemInfos) {
+		for (OrderItemInfo info : itemInfos) {
 			OrderItem item = OrderItem.create(
 				new OrderProduct(info.productId(), info.productName(), info.quantity())
 			);

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
@@ -19,16 +19,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "p_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
-	@Id
+	@Getter
 	@GeneratedValue(strategy = GenerationType.UUID)
+	@Id
 	private UUID orderId;
-	private UUID hubId;
 	private UUID supplierCompanyId;
 	private UUID receiverCompanyId;
 	@Column(name = "user_id")

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/OrderRequest.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/OrderRequest.java
@@ -1,0 +1,12 @@
+package com.fhsh.daitda.order.domain.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+record OrderRequest(
+	LocalDateTime deadlineAt,
+	String requestMessage
+) {
+}

--- a/src/main/java/com/fhsh/daitda/order/domain/vo/OrderItemInfo.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/vo/OrderItemInfo.java
@@ -1,8 +1,8 @@
-package com.fhsh.daitda.order.application.command;
+package com.fhsh.daitda.order.domain.vo;
 
 import java.util.UUID;
 
-public record OrderItemCommand(
+public record OrderItemInfo(
 	UUID productId,
 	String productName,
 	Integer quantity

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/config/FeignConfig.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/config/FeignConfig.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.order.infrastructure.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.fhsh.daitda.order.infrastructure.external")
+public class FeignConfig {
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyAdapter.java
@@ -1,0 +1,24 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fhsh.daitda.order.application.client.CompanyClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyAdapter implements CompanyClient{
+	@Autowired
+	private final CompanyFeignClient companyFeignClient;
+
+	@Override
+	public Map<UUID, String> getProductNames(UUID supplierCompanyId, List<UUID> productIds) {
+		return companyFeignClient.getProductNames(supplierCompanyId, productIds);
+	}
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyAdapter.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class CompanyAdapter implements CompanyClient{
-	@Autowired
 	private final CompanyFeignClient companyFeignClient;
 
 	@Override

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyFeignClient.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface CompanyFeignClient {
+	Map<UUID, String> getProductNames(UUID supplierCompanyId, List<UUID> productIds);
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyFeignClient.java
@@ -4,6 +4,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "company-service")
 public interface CompanyFeignClient {
-	Map<UUID, String> getProductNames(UUID supplierCompanyId, List<UUID> productIds);
+	@PostMapping("/internal/v1/companies/{companyId}")
+	Map<UUID, String> getProductNames(@PathVariable("companyId") UUID supplierCompanyId, @RequestBody List<UUID> productIds);
 }

--- a/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
+++ b/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fhsh.daitda.order.domain.entity.Order;
-import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
 import com.fhsh.daitda.order.domain.repository.OrderRepository;
 import com.fhsh.daitda.order.infrastructure.infrastructure.OrderRepositoryImpl;
 
@@ -29,9 +29,9 @@ public class OrderRepositoryTest {
 	@Test
 	@DisplayName("Record 기반 OrderProduct를 포함한 주문 저장 및 조회 테스트")
 	public void dbTest() {
-		List<OrderItemCommand> orderItemInfos = List.of(
-			new OrderItemCommand(UUID.randomUUID(),  "오징어", 50),
-			new OrderItemCommand(UUID.randomUUID(),  "갈치", 26)
+		List<OrderItemInfo> orderItemInfos = List.of(
+			new OrderItemInfo(UUID.randomUUID(),  "오징어", 50),
+			new OrderItemInfo(UUID.randomUUID(),  "갈치", 26)
 		);
 
 		Order order = Order.create(orderItemInfos);


### PR DESCRIPTION
## 🌱 설명

order생성 초안 (service 및 companyClient)
## 📌 관련 이슈

- #4 
-코드가 길어져서 중간 pr 생성

## ✅ 주요 변경 사항

- order 생성 비즈니스 로직 일부 구현
  - order save
  - company client에 productName 요청
  - 요청한 productName과 request로 받은 quantity 연결
     <img width="999" height="325" alt="image" src="https://github.com/user-attachments/assets/82093b9a-a5ca-452d-bc8c-e37c64d21ebb" />


## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> company-service와 연결을 위해 패키지 구조를 아래와 같이 설정
- infrastructure package에 feignclient와 CompanyAdapter를 두고 CompanyAdapter 내부에서 feignclient 호출
- CompanyAdapter는 실제로 application에 있는 client의 구현체
- 따라서 service에서 client 패키지 추가로 구성 (외구 기술과 독립)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 주문 생성 기능 추가
  * 회사 서비스를 통한 상품명 자동 조회 기능

* **개선**
  * 주문 항목 구조 최적화
  * 주문 요청 정보(기한, 메시지) 통합 관리

* **리팩토링**
  * 주문 생성 서비스 아키텍처 개선
  * 외부 회사 서비스 연동 기반 구축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->