### PR TITLE
4 feature createorder

### DIFF
--- a/src/main/java/com/fhsh/daitda/order/application/client/DeliveryClient.java
+++ b/src/main/java/com/fhsh/daitda/order/application/client/DeliveryClient.java
@@ -1,0 +1,7 @@
+package com.fhsh.daitda.order.application.client;
+
+import java.util.UUID;
+
+public interface DeliveryClient {
+	UUID createDelivery(UUID orderId, UUID supplierCompanyId, UUID receiverCompanyId);
+}

--- a/src/main/java/com/fhsh/daitda/order/application/client/HubInventoryClient.java
+++ b/src/main/java/com/fhsh/daitda/order/application/client/HubInventoryClient.java
@@ -1,8 +1,12 @@
 package com.fhsh.daitda.order.application.client;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import com.fhsh.daitda.order.application.command.OrderItemCommand;
+
 public interface HubInventoryClient {
-	boolean decreaseHubInventory(UUID supplierCompanyId, UUID productId, int quantity);
-	boolean restoreHubInventory(UUID hubInventoryId, int quantity);
+	Map<UUID, UUID> decreaseHubInventory(UUID supplierCompanyId, List<OrderItemCommand> orderItems);
+	void restoreHubInventory(UUID hubInventoryId, int quantity);
 }

--- a/src/main/java/com/fhsh/daitda/order/application/client/HubInventoryClient.java
+++ b/src/main/java/com/fhsh/daitda/order/application/client/HubInventoryClient.java
@@ -5,8 +5,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.application.command.RestoreHubInventoryCommand;
 
 public interface HubInventoryClient {
 	Map<UUID, UUID> decreaseHubInventory(UUID supplierCompanyId, List<OrderItemCommand> orderItems);
-	void restoreHubInventory(UUID hubInventoryId, int quantity);
+	void restoreHubInventory(List<RestoreHubInventoryCommand> hubInventoryCommands);
 }

--- a/src/main/java/com/fhsh/daitda/order/application/client/HubInventoryClient.java
+++ b/src/main/java/com/fhsh/daitda/order/application/client/HubInventoryClient.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.order.application.client;
+
+import java.util.UUID;
+
+public interface HubInventoryClient {
+	boolean decreaseHubInventory(UUID supplierCompanyId, UUID productId, int quantity);
+	boolean restoreHubInventory(UUID hubInventoryId, int quantity);
+}

--- a/src/main/java/com/fhsh/daitda/order/application/command/OrderItemCommand.java
+++ b/src/main/java/com/fhsh/daitda/order/application/command/OrderItemCommand.java
@@ -1,6 +1,5 @@
 package com.fhsh.daitda.order.application.command;
 
-import java.util.List;
 import java.util.UUID;
 
 

--- a/src/main/java/com/fhsh/daitda/order/application/command/RestoreHubInventoryCommand.java
+++ b/src/main/java/com/fhsh/daitda/order/application/command/RestoreHubInventoryCommand.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.order.application.command;
+
+import java.util.UUID;
+
+public record RestoreHubInventoryCommand(
+	UUID hubInventoryId,
+	int quantity
+) {
+}

--- a/src/main/java/com/fhsh/daitda/order/application/service/OrderErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/OrderErrorCode.java
@@ -1,0 +1,18 @@
+package com.fhsh.daitda.order.application.service;
+
+import org.springframework.http.HttpStatus;
+
+import com.fhsh.daitda.exception.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+	//external error
+	DELIVERY_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DELIVERY_SERVICE_ERROR");
+
+	private final HttpStatus status;
+	private final String description;
+}

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -4,10 +4,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.fhsh.daitda.order.application.client.CompanyClient;
+import com.fhsh.daitda.order.application.client.DeliveryClient;
+import com.fhsh.daitda.order.application.client.HubInventoryClient;
 import com.fhsh.daitda.order.application.command.OrderCreateCommand;
 import com.fhsh.daitda.order.application.command.OrderItemCommand;
 import com.fhsh.daitda.order.application.result.OrderCreateResult;
@@ -19,8 +20,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class OrderCommandServiceImpl implements OrderCommandService {
-	@Autowired
 	private final CompanyClient companyClient;
+	private final HubInventoryClient hubInventoryClient;
+	private final DeliveryClient deliveryClient;
 
 	public OrderCreateResult createOrder(OrderCreateCommand orderCreateCommand) {
 		List<UUID> productIds = orderCreateCommand.orderItems().stream()
@@ -28,7 +30,14 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 			.toList();
 		List<OrderItemInfo> itemInfos = createOrderItemInfo(orderCreateCommand.orderItems(), productIds, orderCreateCommand.supplierCompanyId());
 
-		Order order = Order.create(itemInfos);
+		UUID supplierCompanyId = orderCreateCommand.supplierCompanyId();
+		UUID receiverCompanyId = orderCreateCommand.receiverCompanyId();
+
+		Map<UUID, UUID> inventoryInfos = hubInventoryClient.decreaseHubInventory(supplierCompanyId, orderCreateCommand.orderItems());
+		Order order = Order.create(itemInfos, inventoryInfos);
+		//todo: 실패 시 복구 로직 필요 -> hubInventoryClient.restoreHubInventory()
+		UUID deliveryId = deliveryClient.createDelivery(order.getOrderId(), supplierCompanyId, receiverCompanyId);
+		order.complete(deliveryId);
 
 		return OrderCreateResult.from(order);
 	}

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.order.application.client.CompanyClient;
@@ -31,6 +32,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 	private final HubInventoryClient hubInventoryClient;
 	private final DeliveryClient deliveryClient;
 
+	@Transactional
 	public OrderCreateResult createOrder(OrderCreateCommand orderCreateCommand) {
 		List<UUID> productIds = orderCreateCommand.orderItems().stream()
 			.map(OrderItemCommand::productId)
@@ -50,6 +52,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 			itemInfos,
 			inventoryInfos);
 
+		orderRepository.save(order);
+
 		UUID deliveryId = null;
 		try {
 			deliveryId = deliveryClient.createDelivery(order.getOrderId(), supplierCompanyId, receiverCompanyId);
@@ -62,8 +66,6 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 			throw new BusinessException(OrderErrorCode.DELIVERY_SERVICE_ERROR);
 		}
 		order.complete(deliveryId);
-
-		orderRepository.save(order);
 
 		return OrderCreateResult.from(order);
 	}

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class OrderCommandServiceImpl implements OrderCommandService {
+	private final UUID userId; //실제 userID오면 삭제 예정
 	private final OrderRepository orderRepository;
 
 	private final CompanyClient companyClient;
@@ -47,6 +48,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 			orderCreateCommand.orderItems());
 		Order order = Order.create(supplierCompanyId,
 			receiverCompanyId,
+			userId,
 			orderCreateCommand.deadlineAt(),
 			orderCreateCommand.requestMessage(),
 			itemInfos,

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -41,7 +41,12 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 
 		Map<UUID, UUID> inventoryInfos = hubInventoryClient.decreaseHubInventory(supplierCompanyId,
 			orderCreateCommand.orderItems());
-		Order order = Order.create(itemInfos, inventoryInfos);
+		Order order = Order.create(supplierCompanyId,
+			receiverCompanyId,
+			orderCreateCommand.deadlineAt(),
+			orderCreateCommand.requestMessage(),
+			itemInfos,
+			inventoryInfos);
 
 		UUID deliveryId = null;
 		try {

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -11,15 +11,20 @@ import com.fhsh.daitda.order.application.client.DeliveryClient;
 import com.fhsh.daitda.order.application.client.HubInventoryClient;
 import com.fhsh.daitda.order.application.command.OrderCreateCommand;
 import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.application.command.RestoreHubInventoryCommand;
 import com.fhsh.daitda.order.application.result.OrderCreateResult;
 import com.fhsh.daitda.order.domain.entity.Order;
+import com.fhsh.daitda.order.domain.repository.OrderRepository;
 import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
 public class OrderCommandServiceImpl implements OrderCommandService {
+	private final OrderRepository orderRepository;
+
 	private final CompanyClient companyClient;
 	private final HubInventoryClient hubInventoryClient;
 	private final DeliveryClient deliveryClient;
@@ -28,20 +33,35 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 		List<UUID> productIds = orderCreateCommand.orderItems().stream()
 			.map(OrderItemCommand::productId)
 			.toList();
-		List<OrderItemInfo> itemInfos = createOrderItemInfo(orderCreateCommand.orderItems(), productIds, orderCreateCommand.supplierCompanyId());
+		List<OrderItemInfo> itemInfos = createOrderItemInfo(orderCreateCommand.orderItems(), productIds,
+			orderCreateCommand.supplierCompanyId());
 
 		UUID supplierCompanyId = orderCreateCommand.supplierCompanyId();
 		UUID receiverCompanyId = orderCreateCommand.receiverCompanyId();
 
-		Map<UUID, UUID> inventoryInfos = hubInventoryClient.decreaseHubInventory(supplierCompanyId, orderCreateCommand.orderItems());
+		Map<UUID, UUID> inventoryInfos = hubInventoryClient.decreaseHubInventory(supplierCompanyId,
+			orderCreateCommand.orderItems());
 		Order order = Order.create(itemInfos, inventoryInfos);
-		//todo: 실패 시 복구 로직 필요 -> hubInventoryClient.restoreHubInventory()
-		UUID deliveryId = deliveryClient.createDelivery(order.getOrderId(), supplierCompanyId, receiverCompanyId);
+
+		UUID deliveryId = null;
+		try {
+			deliveryId = deliveryClient.createDelivery(order.getOrderId(), supplierCompanyId, receiverCompanyId);
+		} catch (FeignException e) {
+			List<RestoreHubInventoryCommand> hubInventoryCommands = order.getOrderItems()
+				.stream()
+				.map(item -> new RestoreHubInventoryCommand(item.getHubInventoryId(), item.getQuantity()))
+				.toList();
+			hubInventoryClient.restoreHubInventory(hubInventoryCommands);
+		}
 		order.complete(deliveryId);
+
+		orderRepository.save(order);
 
 		return OrderCreateResult.from(order);
 	}
-	private List<OrderItemInfo> createOrderItemInfo(List<OrderItemCommand> orderItemCommands, List<UUID> productIds, UUID supplierCompanyId) {
+
+	private List<OrderItemInfo> createOrderItemInfo(List<OrderItemCommand> orderItemCommands, List<UUID> productIds,
+		UUID supplierCompanyId) {
 		Map<UUID, String> productNames = companyClient.getProductNames(supplierCompanyId, productIds);
 
 		return orderItemCommands.stream().map(

--- a/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/fhsh/daitda/order/application/service/command/OrderCommandServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.order.application.client.CompanyClient;
 import com.fhsh.daitda.order.application.client.DeliveryClient;
 import com.fhsh.daitda.order.application.client.HubInventoryClient;
@@ -13,6 +14,7 @@ import com.fhsh.daitda.order.application.command.OrderCreateCommand;
 import com.fhsh.daitda.order.application.command.OrderItemCommand;
 import com.fhsh.daitda.order.application.command.RestoreHubInventoryCommand;
 import com.fhsh.daitda.order.application.result.OrderCreateResult;
+import com.fhsh.daitda.order.application.service.OrderErrorCode;
 import com.fhsh.daitda.order.domain.entity.Order;
 import com.fhsh.daitda.order.domain.repository.OrderRepository;
 import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
@@ -57,6 +59,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 				.map(item -> new RestoreHubInventoryCommand(item.getHubInventoryId(), item.getQuantity()))
 				.toList();
 			hubInventoryClient.restoreHubInventory(hubInventoryCommands);
+			throw new BusinessException(OrderErrorCode.DELIVERY_SERVICE_ERROR);
 		}
 		order.complete(deliveryId);
 

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
@@ -55,16 +55,19 @@ public class Order extends BaseUserEntity {
 	}
 
 	@Builder
-	private Order(UUID supplierCompanyId, UUID receiverCompanyId, LocalDateTime deadlineAt, String requestMsg) {
+	private Order(UUID supplierCompanyId, UUID receiverCompanyId, UUID ordererId, LocalDateTime deadlineAt, String requestMsg) {
 		this.supplierCompanyId = supplierCompanyId;
 		this.receiverCompanyId = receiverCompanyId;
+		this.ordererId = ordererId;
 		this.orderRequest = new OrderRequest(deadlineAt, requestMsg);
 
 	}
 
 	// Order 와 OrderItem 저장 확인 위해 간단히, 추후 수정 예정
-	public static Order create(UUID supplierCompanyId,
+	public static Order create(
+		UUID supplierCompanyId,
 		UUID receiverCompanyId,
+		UUID ordererId,
 		LocalDateTime deadlineAt,
 		String requestMsg,
 		List<OrderItemInfo> itemInfos,
@@ -73,6 +76,7 @@ public class Order extends BaseUserEntity {
 		Order order = Order.builder()
 			.supplierCompanyId(supplierCompanyId)
 			.receiverCompanyId(receiverCompanyId)
+			.ordererId(ordererId)
 			.deadlineAt(deadlineAt)
 			.requestMsg(requestMsg)
 			.build();

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
@@ -38,6 +38,7 @@ public class Order extends BaseUserEntity {
 	private UUID ordererId;
 	private UUID deliveryId;
 
+	@Getter
 	@OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<OrderItem> orderItems = new ArrayList<>();
 

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
@@ -1,5 +1,6 @@
 package com.fhsh.daitda.order.domain.entity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,9 +54,28 @@ public class Order extends BaseUserEntity {
 		item.setOrder(this);  // 양쪽 동시 세팅
 	}
 
+	@Builder
+	private Order(UUID supplierCompanyId, UUID receiverCompanyId, LocalDateTime deadlineAt, String requestMsg) {
+		this.supplierCompanyId = supplierCompanyId;
+		this.receiverCompanyId = receiverCompanyId;
+		this.orderRequest = new OrderRequest(deadlineAt, requestMsg);
+
+	}
+
 	// Order 와 OrderItem 저장 확인 위해 간단히, 추후 수정 예정
-	public static Order create(List<OrderItemInfo> itemInfos, Map<UUID, UUID> hubInventoryInfos) {
-		Order order = new Order();
+	public static Order create(UUID supplierCompanyId,
+		UUID receiverCompanyId,
+		LocalDateTime deadlineAt,
+		String requestMsg,
+		List<OrderItemInfo> itemInfos,
+		Map<UUID, UUID> hubInventoryInfos) {
+
+		Order order = Order.builder()
+			.supplierCompanyId(supplierCompanyId)
+			.receiverCompanyId(receiverCompanyId)
+			.deadlineAt(deadlineAt)
+			.requestMsg(requestMsg)
+			.build();
 
 		order.orderStatus = OrderStatus.CREATED;
 

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/Order.java
@@ -1,13 +1,14 @@
 package com.fhsh.daitda.order.domain.entity;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import com.fhsh.daitda.domain.BaseUserEntity;
-import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
 import com.fhsh.daitda.order.domain.enums.OrderStatus;
+import com.fhsh.daitda.order.domain.vo.OrderItemInfo;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -51,17 +52,23 @@ public class Order extends BaseUserEntity {
 	}
 
 	// Order 와 OrderItem 저장 확인 위해 간단히, 추후 수정 예정
-	public static Order create(List<OrderItemInfo> itemInfos) {
+	public static Order create(List<OrderItemInfo> itemInfos, Map<UUID, UUID> hubInventoryInfos) {
 		Order order = new Order();
 
 		order.orderStatus = OrderStatus.CREATED;
 
 		for (OrderItemInfo info : itemInfos) {
 			OrderItem item = OrderItem.create(
+				hubInventoryInfos.get(info.productId()),
 				new OrderProduct(info.productId(), info.productName(), info.quantity())
 			);
 			order.addOrderItem(item);
 		}
 		return order;
+	}
+
+	public void complete(UUID deliveryId) {
+		this.deliveryId = deliveryId;
+		this.orderStatus = OrderStatus.COMPLETED;
 	}
 }

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/OrderItem.java
@@ -28,7 +28,7 @@ public class OrderItem extends BaseUserEntity {
 	@Embedded
 	private OrderProduct orderProduct;
 
-	static OrderItem create(OrderProduct product) {
+	static OrderItem create(UUID hubInventoryId, OrderProduct product) {
 		OrderItem item = new OrderItem();
 		item.orderProduct = product;
 		return item;

--- a/src/main/java/com/fhsh/daitda/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/fhsh/daitda/order/domain/entity/OrderItem.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 
 @Entity
 public class OrderItem extends BaseUserEntity {
@@ -23,6 +24,7 @@ public class OrderItem extends BaseUserEntity {
 	@JoinColumn(name = "order_id", nullable = false)
 	private Order order;
 
+	@Getter
 	private UUID hubInventoryId;
 
 	@Embedded
@@ -36,5 +38,9 @@ public class OrderItem extends BaseUserEntity {
 
 	protected void setOrder(Order order) {
 		this.order = order;
+	}
+
+	public int getQuantity() {
+		return this.orderProduct.quantity();
 	}
 }

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/CompanyAdapter.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.fhsh.daitda.order.application.client.CompanyClient;

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryAdapter.java
@@ -1,0 +1,23 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.fhsh.daitda.order.application.client.CompanyClient;
+import com.fhsh.daitda.order.application.client.DeliveryClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryAdapter implements DeliveryClient {
+	private final DeliveryFeignClient deliveryFeignClient;
+
+	public UUID createDelivery(UUID orderId, UUID supplierCompanyId, UUID receiverCompanyId) {
+		DeliveryRequestDto.Creation requestDto = new DeliveryRequestDto.Creation(orderId, supplierCompanyId, receiverCompanyId);
+		return deliveryFeignClient.createDelivery(requestDto);
+	}
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryAdapter.java
@@ -1,12 +1,9 @@
 package com.fhsh.daitda.order.infrastructure.external;
 
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
-import com.fhsh.daitda.order.application.client.CompanyClient;
 import com.fhsh.daitda.order.application.client.DeliveryClient;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.fhsh.daitda.order.application.client.DeliveryClient;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -14,7 +15,12 @@ public class DeliveryAdapter implements DeliveryClient {
 	private final DeliveryFeignClient deliveryFeignClient;
 
 	public UUID createDelivery(UUID orderId, UUID supplierCompanyId, UUID receiverCompanyId) {
-		DeliveryRequestDto.Creation requestDto = new DeliveryRequestDto.Creation(orderId, supplierCompanyId, receiverCompanyId);
-		return deliveryFeignClient.createDelivery(requestDto);
+		try {
+			DeliveryRequestDto.Creation requestDto = new DeliveryRequestDto.Creation(orderId, supplierCompanyId,
+				receiverCompanyId);
+			return deliveryFeignClient.createDelivery(requestDto);
+		} catch (FeignException e) {
+			throw e;
+		}
 	}
 }

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryFeignClient.java
@@ -1,0 +1,16 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "delivery-service")
+public interface DeliveryFeignClient {
+	@PostMapping("/internal/v1/deliveries")
+	UUID createDelivery(@RequestBody DeliveryRequestDto.Creation requestDto);
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryFeignClient.java
@@ -1,11 +1,8 @@
 package com.fhsh.daitda.order.infrastructure.external;
 
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryRequestDto.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/DeliveryRequestDto.java
@@ -1,0 +1,11 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.UUID;
+
+public class DeliveryRequestDto {
+	public record Creation(
+		UUID orderId,
+		UUID supplierCompanyId,
+		UUID receiverCompanyId
+	) {}
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import com.fhsh.daitda.order.application.client.HubInventoryClient;
 import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.application.command.RestoreHubInventoryCommand;
 import com.fhsh.daitda.response.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -37,10 +38,15 @@ public class HubInventoryAdapter implements HubInventoryClient {
 	}
 
 	@Override
-	public void restoreHubInventory(UUID hubInventoryId, int quantity) {
+	public void restoreHubInventory(List<RestoreHubInventoryCommand> hubInventoryCommands) {
+		List<HubInventoryRequestDto.RestoreItem> restoreItems = hubInventoryCommands.stream().map(
+			command -> new HubInventoryRequestDto.RestoreItem(
+				command.hubInventoryId(),
+				command.quantity()
+			)).
+			toList();
 		HubInventoryRequestDto.Restoration hubInventoryDto = new HubInventoryRequestDto.Restoration(
-			hubInventoryId,
-			quantity
+			restoreItems
 		);
 		hubInventoryFeignClient.restoreHubInventory(hubInventoryDto);
 	}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryAdapter.java
@@ -1,11 +1,15 @@
 package com.fhsh.daitda.order.infrastructure.external;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
-import com.fhsh.daitda.order.application.client.DeliveryClient;
 import com.fhsh.daitda.order.application.client.HubInventoryClient;
+import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.response.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,21 +19,29 @@ public class HubInventoryAdapter implements HubInventoryClient {
 	private final HubInventoryFeignClient hubInventoryFeignClient;
 
 	@Override
-	public boolean decreaseHubInventory(UUID supplierCompanyId, UUID productId, int quantity) {
+	public Map<UUID, UUID> decreaseHubInventory(UUID supplierCompanyId, List<OrderItemCommand> orderItems) {
+		List<HubInventoryRequestDto.Item> items = orderItems.stream()
+			.map(item -> new HubInventoryRequestDto.Item(item.productId(), item.quantity()))
+			.toList();
 		HubInventoryRequestDto.Decrease hubInventoryDto = new HubInventoryRequestDto.Decrease(
 			supplierCompanyId,
-			productId,
-			quantity
+			items
 		);
-		return hubInventoryFeignClient.decreaseHubInventory(hubInventoryDto);
+		CommonResponse<HubInventoryResponseDto.Decrease> response = hubInventoryFeignClient.decreaseHubInventory(hubInventoryDto);
+
+		return response.getData().items().stream()
+			.collect(Collectors.toMap(
+				HubInventoryResponseDto.Decrease.InventoryResult::productId,
+				HubInventoryResponseDto.Decrease.InventoryResult::hubInventoryId
+			));
 	}
 
 	@Override
-	public boolean restoreHubInventory(UUID hubInventoryId, int quantity) {
+	public void restoreHubInventory(UUID hubInventoryId, int quantity) {
 		HubInventoryRequestDto.Restoration hubInventoryDto = new HubInventoryRequestDto.Restoration(
 			hubInventoryId,
 			quantity
 		);
-		return hubInventoryFeignClient.restoreHubInventory(hubInventoryDto);
+		hubInventoryFeignClient.restoreHubInventory(hubInventoryDto);
 	}
 }

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryAdapter.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryAdapter.java
@@ -1,0 +1,35 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.fhsh.daitda.order.application.client.DeliveryClient;
+import com.fhsh.daitda.order.application.client.HubInventoryClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class HubInventoryAdapter implements HubInventoryClient {
+	private final HubInventoryFeignClient hubInventoryFeignClient;
+
+	@Override
+	public boolean decreaseHubInventory(UUID supplierCompanyId, UUID productId, int quantity) {
+		HubInventoryRequestDto.Decrease hubInventoryDto = new HubInventoryRequestDto.Decrease(
+			supplierCompanyId,
+			productId,
+			quantity
+		);
+		return hubInventoryFeignClient.decreaseHubInventory(hubInventoryDto);
+	}
+
+	@Override
+	public boolean restoreHubInventory(UUID hubInventoryId, int quantity) {
+		HubInventoryRequestDto.Restoration hubInventoryDto = new HubInventoryRequestDto.Restoration(
+			hubInventoryId,
+			quantity
+		);
+		return hubInventoryFeignClient.restoreHubInventory(hubInventoryDto);
+	}
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryFeignClient.java
@@ -1,0 +1,14 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "hub-service")
+public interface HubInventoryFeignClient{
+	@PatchMapping("/internal/v1/hub-inventories/decrease")
+	boolean decreaseHubInventory(@RequestBody HubInventoryRequestDto.Decrease requestDto);
+	@PatchMapping("/internal/v1/hub-inventories/restoration")
+	boolean restoreHubInventory(@RequestBody HubInventoryRequestDto.Restoration requestDto);
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryFeignClient.java
@@ -5,10 +5,12 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.fhsh.daitda.response.CommonResponse;
+
 @FeignClient(name = "hub-service")
 public interface HubInventoryFeignClient{
 	@PatchMapping("/internal/v1/hub-inventories/decrease")
-	boolean decreaseHubInventory(@RequestBody HubInventoryRequestDto.Decrease requestDto);
+	CommonResponse<HubInventoryResponseDto.Decrease> decreaseHubInventory(@RequestBody HubInventoryRequestDto.Decrease requestDto);
 	@PatchMapping("/internal/v1/hub-inventories/restoration")
-	boolean restoreHubInventory(@RequestBody HubInventoryRequestDto.Restoration requestDto);
+	CommonResponse<Void> restoreHubInventory(@RequestBody HubInventoryRequestDto.Restoration requestDto);
 }

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryRequestDto.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryRequestDto.java
@@ -1,0 +1,16 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.UUID;
+
+public class HubInventoryRequestDto {
+	public record Decrease(
+		UUID supplierCompanyId,
+		UUID productId,
+		Integer quantity
+	) {}
+
+	public record Restoration(
+		UUID hubInventoryid,
+		Integer quantity
+	) {}
+}

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryRequestDto.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryRequestDto.java
@@ -1,16 +1,21 @@
 package com.fhsh.daitda.order.infrastructure.external;
 
+import java.util.List;
 import java.util.UUID;
 
 public class HubInventoryRequestDto {
 	public record Decrease(
 		UUID supplierCompanyId,
-		UUID productId,
-		Integer quantity
+		List<Item> items
 	) {}
 
 	public record Restoration(
 		UUID hubInventoryid,
 		Integer quantity
+	) {}
+
+	public record Item(
+		UUID productId,
+		int quantity
 	) {}
 }

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryRequestDto.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryRequestDto.java
@@ -10,12 +10,16 @@ public class HubInventoryRequestDto {
 	) {}
 
 	public record Restoration(
-		UUID hubInventoryid,
-		Integer quantity
+		List<RestoreItem> restoreItems
 	) {}
 
-	public record Item(
+	protected record Item(
 		UUID productId,
+		int quantity
+	) {}
+
+	protected record RestoreItem(
+		UUID hubInventoryid,
 		int quantity
 	) {}
 }

--- a/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryResponseDto.java
+++ b/src/main/java/com/fhsh/daitda/order/infrastructure/external/HubInventoryResponseDto.java
@@ -1,0 +1,15 @@
+package com.fhsh.daitda.order.infrastructure.external;
+
+import java.util.List;
+import java.util.UUID;
+
+public class HubInventoryResponseDto {
+	public record Decrease(
+		List<InventoryResult> items
+	) {
+		public record InventoryResult(
+			UUID hubInventoryId,
+			UUID productId
+		) {}
+	}
+}

--- a/src/main/java/com/fhsh/daitda/order/presentation/OrderController.java
+++ b/src/main/java/com/fhsh/daitda/order/presentation/OrderController.java
@@ -1,0 +1,26 @@
+package com.fhsh.daitda.order.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fhsh.daitda.order.application.command.OrderCreateCommand;
+import com.fhsh.daitda.order.application.result.OrderCreateResult;
+import com.fhsh.daitda.order.application.service.command.OrderCommandService;
+import com.fhsh.daitda.response.CommonResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController("/api/v1/orders")
+public class OrderController {
+	private final OrderCommandService orderCommandService;
+
+	@PostMapping
+	public ResponseEntity<CommonResponse> createOrder(@RequestBody OrderCreateCommand orderCreateCommand) {
+		OrderCreateResult orderCreateResult = orderCommandService.createOrder(orderCreateCommand);
+		return ResponseEntity.ok(CommonResponse.success(orderCreateResult));
+	}
+
+}

--- a/src/test/java/com/fhsh/daitda/application/OrderCommandServiceImplTest.java
+++ b/src/test/java/com/fhsh/daitda/application/OrderCommandServiceImplTest.java
@@ -1,0 +1,129 @@
+package com.fhsh.daitda.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fhsh.daitda.exception.BusinessException;
+import com.fhsh.daitda.order.application.client.CompanyClient;
+import com.fhsh.daitda.order.application.client.DeliveryClient;
+import com.fhsh.daitda.order.application.client.HubInventoryClient;
+import com.fhsh.daitda.order.application.command.OrderCreateCommand;
+import com.fhsh.daitda.order.application.command.OrderItemCommand;
+import com.fhsh.daitda.order.application.result.OrderCreateResult;
+import com.fhsh.daitda.order.application.service.OrderErrorCode;
+import com.fhsh.daitda.order.application.service.command.OrderCommandServiceImpl;
+import com.fhsh.daitda.order.domain.entity.Order;
+import com.fhsh.daitda.order.domain.repository.OrderRepository;
+
+import feign.FeignException;
+
+@ExtendWith(MockitoExtension.class)
+class OrderCommandServiceImplTest {
+
+	@InjectMocks
+	private OrderCommandServiceImpl orderService;
+
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private CompanyClient companyClient;
+	@Mock
+	private HubInventoryClient hubInventoryClient;
+	@Mock
+	private DeliveryClient deliveryClient;
+
+	@Nested
+	public class CreateOrderTest {
+		@Test
+		@DisplayName("모든 외부 서비스가 정상일 때 주문 생성에 성공해야 한다")
+		void createOrder_Success() {
+			// given
+			UUID supplierId = UUID.randomUUID();
+			UUID receiverId = UUID.randomUUID();
+			UUID productId = UUID.randomUUID();
+			UUID hubInventoryId = UUID.randomUUID();
+			String productName = "테스트 상품";
+
+			OrderCreateCommand command = createTestCommand(supplierId, receiverId, productId);
+
+			// 1. 상품명 조회 Mock
+			given(companyClient.getProductNames(eq(supplierId), anyList()))
+				.willReturn(Map.of(productId, productName));
+
+			// 2. 재고 차감 Mock (ProductId -> HubInventoryId 매핑)
+			given(hubInventoryClient.decreaseHubInventory(eq(supplierId), anyList()))
+				.willReturn(Map.of(productId, hubInventoryId));
+
+			// 3. 배송 생성 Mock (정상적인 UUID 반환)
+			UUID mockDeliveryId = UUID.randomUUID();
+			given(deliveryClient.createDelivery(any(), eq(supplierId), eq(receiverId)))
+				.willReturn(mockDeliveryId);
+
+			// when
+			OrderCreateResult result = orderService.createOrder(command);
+
+			// then
+			assertNotNull(result);
+			// 주문 저장 메서드가 호출되었는지 확인
+			verify(orderRepository, times(1)).save(any(Order.class));
+			// 배송 서비스가 호출되었는지 확인
+			verify(deliveryClient, times(1)).createDelivery(any(), any(), any());
+			// 재고 복구(restore)는 호출되지 않아야 함
+			verify(hubInventoryClient, never()).restoreHubInventory(anyList());
+		}
+
+		@Test
+		@DisplayName("배송 생성 실패 시 재고 복구 로직이 실행되어야 한다")
+		void createOrder_ShouldRestoreInventory_WhenDeliveryFails() {
+			// given
+			UUID supplierId = UUID.randomUUID();
+			UUID receiverId = UUID.randomUUID();
+			UUID productId = UUID.randomUUID();
+			OrderCreateCommand command = createTestCommand(supplierId, receiverId, productId);
+
+			// Mock 설정: 재고 차감 성공 시 Map 반환
+			Map<UUID, UUID> mockInventoryMap = Map.of(UUID.randomUUID(), UUID.randomUUID());
+			given(hubInventoryClient.decreaseHubInventory(any(), any())).willReturn(mockInventoryMap);
+
+			// Mock 설정: 배송 생성 시 FeignException 발생
+			given(deliveryClient.createDelivery(any(), any(), any()))
+				.willThrow(FeignException.class);
+
+			// when & then
+			// 1. assertThrows의 결과로 예외 객체를 받습니다.
+			BusinessException exception = assertThrows(BusinessException.class, () -> {
+				orderService.createOrder(command);
+			});
+
+			// 2. 예외 내부의 에러 코드가 내가 설정한 것과 같은지 검증합니다.
+			assertEquals(OrderErrorCode.DELIVERY_SERVICE_ERROR, exception.getErrorCode());
+
+			// then: 배송 실패 시 restoreHubInventory가 반드시 호출되었는지 검증
+			verify(hubInventoryClient, times(1)).restoreHubInventory(anyList());
+			// then: 주문이 저장되지 않아야 함 (예외로 인해)
+			verify(orderRepository, never()).save(any());
+		}
+
+		private OrderCreateCommand createTestCommand(UUID supplierId, UUID receiverId, UUID productId) {
+			return new OrderCreateCommand(
+				supplierId,
+				receiverId,
+				null, // address 등 필요한 필드
+				null,
+				List.of(new OrderItemCommand(productId, 2))
+			);
+		}
+	}
+}

--- a/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
+++ b/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
@@ -43,7 +43,7 @@ public class OrderRepositoryTest {
 			prod2, hubInvenId2
 		);
 
-		Order order = Order.create(orderItemInfos, inventoryMap);
+		Order order = Order.create(null, null, null, null, orderItemInfos, inventoryMap);
 
 		Order savedOrder = orderRepository.save(order);
 		UUID orderId = (UUID) ReflectionTestUtils.getField(savedOrder, "orderId");

--- a/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
+++ b/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
@@ -3,6 +3,7 @@ package com.fhsh.daitda.domain;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,12 +30,20 @@ public class OrderRepositoryTest {
 	@Test
 	@DisplayName("Record 기반 OrderProduct를 포함한 주문 저장 및 조회 테스트")
 	public void dbTest() {
+		final UUID hubInvenId1 = UUID.randomUUID();
+		final UUID hubInvenId2 = UUID.randomUUID();
+		final UUID prod1 = UUID.randomUUID();
+		final UUID prod2 = UUID.randomUUID();
 		List<OrderItemInfo> orderItemInfos = List.of(
-			new OrderItemInfo(UUID.randomUUID(),  "오징어", 50),
-			new OrderItemInfo(UUID.randomUUID(),  "갈치", 26)
+			new OrderItemInfo(prod1,  "오징어", 50),
+			new OrderItemInfo(prod2,  "갈치", 26)
+		);
+		Map<UUID, UUID> inventoryMap = Map.of(
+			prod1, hubInvenId1,
+			prod2, hubInvenId2
 		);
 
-		Order order = Order.create(orderItemInfos);
+		Order order = Order.create(orderItemInfos, inventoryMap);
 
 		Order savedOrder = orderRepository.save(order);
 		UUID orderId = (UUID) ReflectionTestUtils.getField(savedOrder, "orderId");

--- a/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
+++ b/src/test/java/com/fhsh/daitda/domain/OrderRepositoryTest.java
@@ -43,7 +43,7 @@ public class OrderRepositoryTest {
 			prod2, hubInvenId2
 		);
 
-		Order order = Order.create(null, null, null, null, orderItemInfos, inventoryMap);
+		Order order = Order.create(null, null, null, null, null, orderItemInfos, inventoryMap);
 
 		Order savedOrder = orderRepository.save(order);
 		UUID orderId = (UUID) ReflectionTestUtils.getField(savedOrder, "orderId");


### PR DESCRIPTION
## 🌱 설명

- 주문 생성 로직 구현

## 📌 관련 이슈

- close #4 

## ✅ 주요 변경 사항

- MSA 연동: CompanyClient, HubInventoryClient, DeliveryClient를 통한 분산 환경에서의 주문 프로세스 구축.
- 보상 트랜잭션(Compensating Transaction): 배송 생성 실패 시, FeignException을 캐치하여 차감된 재고를 즉시 복구(restoreHubInventory)하는 로직 구현.
- 데이터 영속화: JPA의 더티 체킹(Dirty Checking)을 활용하여 주문 상태(CREATED → COMPLETED) 변화를 안정적으로 반영.

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 생성 API 확장 — 허브 재고 연동(감소/복구) 및 외부 배송 생성 연계
  * 내부 통신용 요청/응답 DTO, Feign 클라이언트 및 어댑터 추가
  * 주문 도메인에 배송 완료 처리 및 항목-허브재고 연동 반영
  * 오류 식별용 주문 전용 에러 코드 추가
* **테스트**
  * 주문 생성 흐름 단위 테스트 추가 — 성공 및 배송 실패 시 재고 복구 시나리오 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->